### PR TITLE
From bootstrap 4.0.0 beta to stable

### DIFF
--- a/_includes/section/forms.html
+++ b/_includes/section/forms.html
@@ -39,33 +39,41 @@
 			</div>
 			<div class="form-group">
 				<div class="input-group input-group-lg">
-					<span class="input-group-addon">$</span>
+					<div class="input-group-prepend">
+						<span class="input-group-text">$</span>
+					</div>
 					<input type="text" class="form-control" aria-label="Amount (to the nearest dollar)">
-					<span class="input-group-addon">.00</span>
+					<div class="input-group-append">
+						<span class="input-group-text">.00</span>
+					</div>
 				</div>
 			</div>
 			<div class="form-group">
 				<div class="input-group">
-					<span class="input-group-addon">$</span>
+					<div class="input-group-prepend">
+						<span class="input-group-text">$</span>
+					</div>
 					<input type="text" class="form-control" aria-label="Amount (to the nearest dollar)">
-					<span class="input-group-addon">.00</span>
+					<div class="input-group-append">
+						<span class="input-group-text">.00</span>
+					</div>
 				</div>
 			</div>
 			<div class="form-group">
 				<div class="input-group">
-					<span class="input-group-btn">
+					<div class="input-group-prepend">
 						<button class="btn btn-secondary" type="button">Hate it</button>
-					</span>
+					</div>
 					<input type="text" class="form-control" placeholder="Product name" aria-label="Product name">
-					<span class="input-group-btn">
+					<div class="input-group-append">
 						<button class="btn btn-secondary" type="button">Love it</button>
-					</span>
+					</div>
 				</div>
 			</div>
 			<div class="form-group">
 				<div class="input-group">
 					<input type="text" class="form-control" aria-label="Text input with dropdown button">
-					<div class="input-group-btn">
+					<div class="input-group-append">
 						<button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Action</button>
 						<div class="dropdown-menu dropdown-menu-right">
 							<a class="dropdown-item" href="#">Action</a>
@@ -113,7 +121,9 @@
 				<div class="form-inline">
 					<input type="text" class="form-control mb-2 mr-sm-2 mb-sm-0" placeholder="Inline input 1">
 					<div class="input-group mb-2 mr-sm-2 mb-sm-0">
-						<div class="input-group-addon">@</div>
+						<div class="input-group-prepend">
+							<span class="input-group-text">@</span>
+						</div>
 						<input type="text" class="form-control" placeholder="Inline input 2">
 					</div>
 				</div>

--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -1,5 +1,4 @@
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M"
- crossorigin="anonymous">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css" id="hljs-theme">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>


### PR DESCRIPTION
I noticed the markup has changed for input groups. They now use `.input-group-prepend` and `.input-group-append` instead of `.input-group-addon`.

I did not thoroughly check the rest of page.