### PR TITLE
Fixed horizontal overflow

### DIFF
--- a/_includes/sections.html
+++ b/_includes/sections.html
@@ -1,7 +1,7 @@
 <main>
 	{% for section in site.data.sections %}
 		<section class="mb-5 pt-5" id="{{ section.name | handleize | replace: ' ', '-' | downcase }}">
-			<div class="row bg-light py-4 mb-5">
+			<div class="bg-light py-4 mb-5">
 				<div class="container">
 					<div class="d-flex justify-content-between">
 							<h2>


### PR DESCRIPTION
Since `<section>` is already 100% wide, adding .row class to it's child will create horizontal overflow caused by .row's negative horizontal margin.

Removing .row class will fix horizontal overflow and scrollbar will not appear.