### PR TITLE
Fixed "image not found" console error

### DIFF
--- a/_includes/section/cards.html
+++ b/_includes/section/cards.html
@@ -57,10 +57,10 @@
 				</div>
 			</div>
 			<div class="card">
-					<img class="card-img" src="holder.js/100px120" alt="Card image">
+					<img class="card-img" data-src="holder.js/100px120" alt="Card image">
 				  </div>
 			<div class="card">
-				<img class="card-img-top" src="holder.js/100px120" alt="Card image cap">
+				<img class="card-img-top" data-src="holder.js/100px120" alt="Card image cap">
 				<div class="card-body">
 					<p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
 				</div>
@@ -72,10 +72,10 @@
 						bit longer.</p>
 					<p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
 				</div>
-				<img class="card-img-bottom" src="holder.js/100px120" alt="Card image cap">
+				<img class="card-img-bottom" data-src="holder.js/100px120" alt="Card image cap">
 			</div>
 			<div class="card">
-				<img class="card-img-top" src="holder.js/100px120" alt="Card image cap">
+				<img class="card-img-top" data-src="holder.js/100px120" alt="Card image cap">
 				<div class="card-body">
 					<h4 class="card-title">Card title</h4>
 					<p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>

--- a/_includes/section/images.html
+++ b/_includes/section/images.html
@@ -5,7 +5,7 @@
 	</div>
 	<div class="col-md-6">
 		<h3 class="mt-5">Thumbnail</h3>
-		<img src="holder.js/200x200" alt="thumbnail image" class="img-thumbnail">
+		<img data-src="holder.js/200x200" alt="thumbnail image" class="img-thumbnail">
 	</div>
 	<div class="col-md-6">
 		<h3 class="mt-5">Figure</h3>
@@ -17,7 +17,7 @@
 	<div class="col-12">
 		<h3 class="mt-5">Media</h3>
 		<div class="media">
-			<img class="d-flex mr-3" src="holder.js/64x64" alt="Generic placeholder image">
+			<img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
 			<div class="media-body">
 				<h5 class="mt-0">Media heading</h5>
 				Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in
@@ -26,7 +26,7 @@
 
 				<div class="media mt-3">
 					<a class="d-flex pr-3" href="#">
-				  <img src="holder.js/64x64" alt="Generic placeholder image">
+				  <img data-src="holder.js/64x64" alt="Generic placeholder image">
 				</a>
 					<div class="media-body">
 						<h5 class="mt-0">Media heading</h5>


### PR DESCRIPTION
Images that are generated by holder.js can be set in data-src instead of src to prevent console error logging